### PR TITLE
feat(portfolio): falling-star cursor + smooth scroll hero

### DIFF
--- a/artifacts/portfolio/src/App.tsx
+++ b/artifacts/portfolio/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Navbar from "@/components/Navbar";
+import CursorEffect from "@/components/CursorEffect";
 import Home from "@/pages/Home";
 import BlogList from "@/pages/BlogList";
 import BlogPost from "@/pages/BlogPost";
@@ -34,6 +35,7 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
+        <CursorEffect />
         <WouterRouter base={import.meta.env.BASE_URL.replace(/\/$/, "")}>
           <Router />
         </WouterRouter>

--- a/artifacts/portfolio/src/components/CursorEffect.tsx
+++ b/artifacts/portfolio/src/components/CursorEffect.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useRef, useState } from "react";
+
+const INTERACTIVE_SELECTOR =
+  "a, button, input, textarea, select, label, [role='button'], [data-cursor='hover']";
+const DESKTOP_POINTER_QUERY = "(any-hover: hover) and (any-pointer: fine)";
+
+type StarParticle = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  tilt: number;
+};
+
+export default function CursorEffect() {
+  const [enabled, setEnabled] = useState(false);
+  const starRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const targetRef = useRef({ x: 0, y: 0 });
+  const smoothRef = useRef({ x: 0, y: 0 });
+  const particlesRef = useRef<StarParticle[]>([]);
+  const lastPointRef = useRef({ x: 0, y: 0, t: 0 });
+  const velocityRef = useRef({ x: 0, y: 0 });
+  const targetAngleRef = useRef(0);
+  const currentAngleRef = useRef(0);
+  const hoveringRef = useRef(false);
+  const visibleRef = useRef(false);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const canUseFinePointer = window.matchMedia(DESKTOP_POINTER_QUERY).matches;
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    setEnabled(canUseFinePointer && !prefersReducedMotion);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const star = starRef.current;
+    const canvas = canvasRef.current;
+    if (!star || !canvas) return;
+
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const dpr = Math.max(window.devicePixelRatio || 1, 1);
+
+    const resize = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+
+    const setVisible = (isVisible: boolean) => {
+      const opacity = isVisible ? "1" : "0";
+      star.style.opacity = opacity;
+      canvas.style.opacity = opacity;
+    };
+
+    const spawnStars = (x: number, y: number, speed: number) => {
+      const count = Math.min(3, Math.max(1, Math.floor(speed / 28)));
+
+      for (let i = 0; i < count; i += 1) {
+        const maxLife = 18 + Math.random() * 18;
+        particlesRef.current.push({
+          x: x + (Math.random() - 0.5) * 3,
+          y: y + (Math.random() - 0.5) * 3,
+          vx: (Math.random() - 0.5) * 0.9,
+          vy: 0.3 + Math.random() * 0.6 + speed * 0.004,
+          life: maxLife,
+          maxLife,
+          size: 1 + Math.random() * (hoveringRef.current ? 1.2 : 0.8),
+          tilt: Math.random() * Math.PI,
+        });
+      }
+
+      if (particlesRef.current.length > 90) {
+        particlesRef.current.splice(0, particlesRef.current.length - 90);
+      }
+    };
+
+    const handleMove = (event: PointerEvent) => {
+      if (event.pointerType === "touch") return;
+
+      const now = performance.now();
+      const dt = Math.max(now - (lastPointRef.current.t || now), 1);
+      const dx = event.clientX - lastPointRef.current.x;
+      const dy = event.clientY - lastPointRef.current.y;
+      const speed = Math.hypot(dx, dy) / dt * 16;
+      velocityRef.current = { x: dx, y: dy };
+      if (speed > 0.01) {
+        targetAngleRef.current = (Math.atan2(dy, dx) * 180) / Math.PI;
+      }
+
+      targetRef.current.x = event.clientX;
+      targetRef.current.y = event.clientY;
+      spawnStars(event.clientX, event.clientY, speed);
+      lastPointRef.current = { x: event.clientX, y: event.clientY, t: now };
+
+      if (!visibleRef.current) {
+        visibleRef.current = true;
+        setVisible(true);
+      }
+    };
+
+    const handleOver = (event: PointerEvent) => {
+      if (event.pointerType === "touch") return;
+      const target = event.target as Element | null;
+      hoveringRef.current = !!target?.closest(INTERACTIVE_SELECTOR);
+    };
+
+    const handleOut = (event: PointerEvent) => {
+      if (event.pointerType === "touch") return;
+      if (!event.relatedTarget) {
+        visibleRef.current = false;
+        setVisible(false);
+      }
+    };
+
+    const animate = () => {
+      const lerp = 0.18;
+      smoothRef.current.x += (targetRef.current.x - smoothRef.current.x) * lerp;
+      smoothRef.current.y += (targetRef.current.y - smoothRef.current.y) * lerp;
+      currentAngleRef.current += (targetAngleRef.current - currentAngleRef.current) * 0.15;
+
+      const scale = hoveringRef.current ? 1.35 : 1;
+      star.style.transform = `translate3d(${targetRef.current.x - 7}px, ${targetRef.current.y - 7}px, 0) scale(${scale}) rotate(${currentAngleRef.current + 45}deg)`;
+
+      context.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+      particlesRef.current = particlesRef.current.filter((particle) => {
+        particle.life -= 1;
+        if (particle.life <= 0) return false;
+
+        particle.x += particle.vx;
+        particle.y += particle.vy;
+        particle.vy += 0.02;
+        particle.vx *= 0.99;
+        const alpha = particle.life / particle.maxLife;
+
+        context.beginPath();
+        context.moveTo(particle.x, particle.y);
+        context.lineTo(particle.x - particle.vx * 9, particle.y - particle.vy * 9);
+        context.strokeStyle = `rgba(255, 185, 102, ${alpha * 0.28})`;
+        context.lineWidth = Math.max(0.6, particle.size * 0.7);
+        context.stroke();
+
+        context.save();
+        context.translate(particle.x, particle.y);
+        context.rotate(particle.tilt);
+        context.strokeStyle = `rgba(255, 236, 182, ${alpha * 0.76})`;
+        context.lineWidth = 1;
+        context.beginPath();
+        context.moveTo(-particle.size, 0);
+        context.lineTo(particle.size, 0);
+        context.moveTo(0, -particle.size);
+        context.lineTo(0, particle.size);
+        context.stroke();
+        context.restore();
+
+        return (
+          particle.x > -20 &&
+          particle.x < window.innerWidth + 20 &&
+          particle.y > -20 &&
+          particle.y < window.innerHeight + 20
+        );
+      });
+
+      frameRef.current = window.requestAnimationFrame(animate);
+    };
+
+    frameRef.current = window.requestAnimationFrame(animate);
+    window.addEventListener("resize", resize);
+    window.addEventListener("pointermove", handleMove, { passive: true });
+    window.addEventListener("pointerover", handleOver, { passive: true });
+    window.addEventListener("pointerout", handleOut, { passive: true });
+
+    return () => {
+      if (frameRef.current) window.cancelAnimationFrame(frameRef.current);
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerover", handleOver);
+      window.removeEventListener("pointerout", handleOut);
+    };
+  }, [enabled]);
+
+  if (!enabled) return null;
+
+  return (
+    <>
+      <canvas ref={canvasRef} className="cursor-fx cursor-stars-canvas" aria-hidden />
+      <div ref={starRef} className="cursor-fx cursor-shooting-star" aria-hidden>
+        <span className="cursor-star-line cursor-star-line-a" />
+        <span className="cursor-star-line cursor-star-line-b" />
+      </div>
+    </>
+  );
+}

--- a/artifacts/portfolio/src/index.css
+++ b/artifacts/portfolio/src/index.css
@@ -272,3 +272,59 @@
   background: hsl(38 85% 52% / 0.3);
   color: hsl(var(--foreground));
 }
+
+/* Cursor effect */
+.cursor-fx {
+  position: fixed;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  z-index: 12000;
+  opacity: 0;
+  will-change: transform, opacity;
+  transition: opacity 120ms ease;
+}
+
+.cursor-stars-canvas {
+  z-index: 11999;
+}
+
+.cursor-shooting-star {
+  width: 14px;
+  height: 14px;
+  transform-origin: 50% 50%;
+  z-index: 12001;
+}
+
+.cursor-star-line {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 9999px;
+  background: linear-gradient(
+    90deg,
+    hsl(38 96% 78% / 0.2) 0%,
+    hsl(42 96% 72% / 0.95) 50%,
+    hsl(38 96% 78% / 0.2) 100%
+  );
+  box-shadow: 0 0 8px hsl(40 92% 68% / 0.6);
+}
+
+.cursor-star-line-a {
+  width: 12px;
+  height: 1.6px;
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.cursor-star-line-b {
+  width: 12px;
+  height: 1.6px;
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+@media (pointer: coarse), (prefers-reduced-motion: reduce) {
+  .cursor-fx {
+    display: none !important;
+  }
+}

--- a/artifacts/portfolio/src/pages/Home.tsx
+++ b/artifacts/portfolio/src/pages/Home.tsx
@@ -1,8 +1,16 @@
 import { useState, useEffect, useRef } from "react";
 import { Link } from "wouter";
-import { motion, useInView, AnimatePresence } from "framer-motion";
+import {
+  motion,
+  useInView,
+  AnimatePresence,
+  useScroll,
+  useSpring,
+  useTransform,
+} from "framer-motion";
 import HeroScene from "@/components/HeroScene";
 import {
+  type BlogPost,
   useGetRecentBlogPosts,
   useSendMessage,
 } from "@workspace/api-client-react";
@@ -111,6 +119,16 @@ function FadeInSection({ children, delay = 0 }: { children: React.ReactNode; del
 function HeroSection() {
   const [roleIdx, setRoleIdx] = useState(0);
   const [mouse, setMouse] = useState({ x: 0, y: 0 });
+  const { scrollYProgress } = useScroll();
+  const smoothProgress = useSpring(scrollYProgress, {
+    stiffness: 130,
+    damping: 24,
+    mass: 0.25,
+  });
+  const sceneY = useTransform(smoothProgress, [0, 0.3], [0, 42]);
+  const contentY = useTransform(smoothProgress, [0, 0.22], [0, -70]);
+  const contentOpacity = useTransform(smoothProgress, [0, 0.22], [1, 0.35]);
+  const scrollHintOpacity = useTransform(smoothProgress, [0, 0.16], [1, 0]);
 
   useEffect(() => {
     const interval = setInterval(() => setRoleIdx((i) => (i + 1) % ROLES.length), 2800);
@@ -131,9 +149,9 @@ function HeroSection() {
   return (
     <section className="relative min-h-screen flex items-center overflow-hidden" style={{ background: "hsl(var(--background))" }}>
       {/* 3D Canvas — full background */}
-      <div className="absolute inset-0 pointer-events-none">
+      <motion.div className="absolute inset-0 pointer-events-none" style={{ y: sceneY }}>
         <HeroScene mouseX={mouse.x} mouseY={mouse.y} />
-      </div>
+      </motion.div>
 
       {/* Gradient vignette */}
       <div
@@ -150,7 +168,10 @@ function HeroSection() {
       />
 
       {/* Content */}
-      <div className="relative z-10 max-w-6xl mx-auto px-6 py-32 w-full">
+      <motion.div
+        className="relative z-10 max-w-6xl mx-auto px-6 py-32 w-full"
+        style={{ y: contentY, opacity: contentOpacity }}
+      >
         <motion.div
           initial={{ opacity: 0, y: 40 }}
           animate={{ opacity: 1, y: 0 }}
@@ -224,11 +245,12 @@ function HeroSection() {
           </div>
         </motion.div>
 
-      </div>
+      </motion.div>
 
       {/* Scroll indicator */}
       <motion.div
         className="absolute bottom-12 right-8 flex flex-col items-center gap-2"
+        style={{ opacity: scrollHintOpacity }}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 1, duration: 0.8 }}
@@ -441,14 +463,18 @@ function ProjectsSection() {
 
 function BlogSection() {
   const { data: posts, isLoading } = useGetRecentBlogPosts();
+  type BlogPreview = Pick<BlogPost, "title" | "excerpt" | "tags" | "publishedAt"> & {
+    slug?: string;
+  };
 
-  const placeholders = [
+  const placeholders: BlogPreview[] = [
     { title: "Building Agentic RAG Systems with LangGraph", excerpt: "A deep dive into constructing multi-step retrieval-augmented generation pipelines.", tags: ["AI", "LangGraph", "RAG"], publishedAt: "2026-03-15" },
     { title: "Contributing AWS SigV4 Auth to Jaeger", excerpt: "How I implemented IAM authentication for Jaeger's Elasticsearch/OpenSearch storage backend.", tags: ["Go", "CNCF", "AWS"], publishedAt: "2026-02-28" },
     { title: "MCP in Practice: Building Agentic Tools", excerpt: "A practical guide to the Model Context Protocol and building MCP servers that integrate with Claude.", tags: ["AI", "MCP", "Python"], publishedAt: "2026-03-25" },
   ];
 
-  const displayPosts = posts ?? placeholders;
+  const displayPosts: BlogPreview[] =
+    Array.isArray(posts) ? posts : placeholders;
 
   return (
     <section id="blog" className="py-28" style={{ background: "hsl(var(--card))" }}>
@@ -475,7 +501,7 @@ function BlogSection() {
           </div>
         ) : (
           <div className="grid md:grid-cols-3 gap-6">
-            {displayPosts.slice(0, 3).map((post: any, i: number) => (
+            {displayPosts.slice(0, 3).map((post, i) => (
               <FadeInSection key={post.slug ?? i} delay={i * 0.08}>
                 <Link href={post.slug ? `/blog/${post.slug}` : "/blog"}>
                   <div
@@ -489,7 +515,7 @@ function BlogSection() {
                     onMouseLeave={(e) => (e.currentTarget.style.borderColor = "hsl(var(--border))")}
                   >
                     <div className="flex flex-wrap gap-1.5 mb-4">
-                      {post.tags?.slice(0, 2).map((tag: string) => (
+                      {post.tags?.slice(0, 2).map((tag) => (
                         <span key={tag} className="tag-pill">{tag}</span>
                       ))}
                     </div>


### PR DESCRIPTION
## Summary
- add a new global `CursorEffect` with a simple star cursor and falling-star spark trail (desktop only)
- remove the previous round cursor visual and replace it with a cleaner shooting-star style
- add smooth hero scroll parallax/fade animation for the landing section
- harden home blog preview rendering by safely handling non-array API payloads

## Why
This improves the portfolio interaction feel while keeping the visual direction minimal and on-theme. It also prevents a homepage runtime crash caused by unsafe recent-posts shape assumptions.

## Validation (deploy-safe)
- `pnpm install --frozen-lockfile`
- `pnpm exec tsc -b lib/db lib/api-zod lib/api-client-react --force`
- `pnpm --filter @workspace/api-server run typecheck`
- `pnpm --filter @workspace/api-server run build`
- `pnpm --filter @workspace/portfolio run typecheck`
- `PORT=3000 BASE_PATH=/ pnpm --filter @workspace/portfolio run build`

All passed locally.

Closes #7
